### PR TITLE
Use use_inline_resources only if defined

### DIFF
--- a/providers/x509.rb
+++ b/providers/x509.rb
@@ -5,7 +5,7 @@
 #
 require 'openssl'
 
-use_inline_resources
+use_inline_resources if defined?(use_inline_resources)
 
 attr_reader :key_file, :key, :cert, :ef
 


### PR DESCRIPTION
use_inline_resources doesn't work in all versions of Chef

NameError: undefined local variable or method `use_inline_resources'