### PR TITLE
fix a problem with variable scoping.

### DIFF
--- a/providers/x509.rb
+++ b/providers/x509.rb
@@ -13,12 +13,15 @@ action :create  do
   unless ::File.exists? new_resource.name
     create_keys
 
+    my_cert = self.cert
+    my_key = self.key
+
     file new_resource.name do
       action :create_if_missing
       mode  new_resource.mode
       owner new_resource.owner
       group new_resource.group
-      content cert.to_pem
+      content my_cert.to_pem
     end
 
     file new_resource.key_file do
@@ -26,7 +29,7 @@ action :create  do
       mode  new_resource.mode
       owner new_resource.owner
       group new_resource.group
-      content key.to_pem
+      content my_key.to_pem
     end
 
   end


### PR DESCRIPTION
It's possible that this was introduced in chef 12, but I'm getting errors when using the x509 resource saying:

NoMethodError: undefined method `cert' for Chef::Resource::File
and
NoMethodError: undefined method `key' for Chef::Resource::File

The problem is that inside the file resource, self refers to the file resource itself, so we need locally scoped variables to hold the data it needs.