### PR TITLE
Create a new module for generating secure passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 openssl Cookbook
 ================
-
 This cookbook provides a library method to generate secure random passwords in recipes using the Ruby OpenSSL library.
 
 It also provides an attribute-driven recipe for upgrading OpenSSL packages.
 
+
 Requirements
 ------------
-
-The `secure_password` works on any platform with OpenSSL Ruby bindings installed, which are a requirement for Chef anyway.
-
 The upgrade recipe works on the following tested platforms:
 
 * Ubuntu 12.04, 14.04
@@ -20,69 +17,20 @@ It may work on other platforms or versions of the above platforms with or withou
 
 [Chef Sugar](https://github.com/sethvargo/chef-sugar) was introduced as a dependency to provide helpers that make the default attribute settings (see Attributes) easier to reason about.
 
+
 Attributes
 ----------
-
 * `node['openssl']['packages']` - An array of packages of openssl. The default attributes attempt to be smart about which packages are the default, but this may need to be changed by users of the `openssl::upgrade` recipe.
 * `node['openssl']['restart_services']` - An array of service resources that use the `node['openssl']['packages']`. This is empty by default as Chef has no reliably reasonable way to detect which applications or services are compiled against these packages. *Note* These each need to be "`service`" resources specified somewhere in the recipes in the node's run list.
 
+
 Recipes
 -------
-
 ### upgrade
 
 The upgrade recipe iterates over the list of packages in the `node['openssl']['packages']` attribute and manages them with the `:upgrade` action. Each package will send `:restart` notification to service resources named by the `node['openssl']['restart_services']` attribute.
 
-Usage
------
-
-Most often this will be used to generate a secure password for an attribute. In a recipe:
-
-```ruby
-::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
-node.set_unless[:my_password] = secure_password
-```
-
 To use the `openssl::upgrade` recipe, set the attributes as mentioned above. For example, we have a "stats_collector" service that uses openssl. It has a recipe that looks like this:
-
-LWRP
-==== 
-
-This cookbook includes an LWRP for generating Self Signed Certificates
-
-## openssl_x509
-generate a pem formatted x509 cert + key  
-
-### Attributes
-`common_name` A String representing the `CN` ssl field
-`org` A String representing the `O` ssl field
-`org_unit` A String representing the `OU` ssl field
-`country` A String representing the `C` ssl field
-`expire` A Fixnum reprenting the number of days from _now_ to expire the cert
-`key_file` Optional A string to the key file to use. If no key is present it will generate and store one. 
-`key_pass` A String that is the key's passphrase
-`key_length` A Fixnum reprenting your desired Bit Length _Default: 2048_
-`owner` The owner of the files _Default: "root"_
-`group` The group of the files _Default: "root"_
-`mode`  The mode to store the files in _Default: "0400"_
-
-### Example usage
-
-    openssl_x509 "/tmp/mycert.pem" do
-      common_name "www.f00bar.com"
-      org "Foo Bar"
-      org_unit "Lab"
-      country "US"
-    end
-
-    
-License and Author
-==================
-
-Author:: Jesse Nelson (<spheromak@gmail.com>)
-Author:: Joshua Timberman (<joshua@opscode.com>)
-=======
-
 
 ```ruby
 node.default['openssl']['restart_services'] = ['stats_collector']
@@ -97,9 +45,74 @@ include_recipe 'openssl::upgrade'
 
 This will ensure that openssl is upgraded to the latest version so the `stats_collector` service won't be exploited (hopefully!).
 
+
+Mixins
+------
+There are two mixins packaged with this cookbook.
+
+### `OpenSSLCookbook::RandomPassword`
+The `RandomPassword` mixin can be used to generate random passwords secure in Chef cookbooks. It uses Ruby's SecureRandom library and is customizable.
+
+```ruby
+Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
+node.set["my_secure_attribute"] = random_password
+node.set["my_secure_attribute"] = random_password(length: 50)
+node.set["my_secure_attribute"] = random_password(length: 50, mode: :base64)
+node.set["my_secure_attribute"] = random_password(length: 50, mode: :base64, encoding: "ASCII")
+```
+
+For a full list of methods and options, please consult the API documentation in the source code (`libraries/random_password.rb`).
+
+### `Opscode::OpenSSL::Password`
+This library should be considered deprecated and may be removed in a future version. Please use `OpenSSLCookbook::RandomPassword` instead. The documentation is kept here for historical reasons.
+
+```ruby
+Chef::Recipe.send(:include, ::Opscode::OpenSSL::Password)
+node.set["my_secure_attribute"] = secure_password
+```
+
+
+LWRP
+----
+This cookbook includes an LWRP for generating Self Signed Certificates
+
+### openssl_x509
+generate a pem formatted x509 cert + key
+
+#### Attributes
+`common_name` A String representing the `CN` ssl field
+`org` A String representing the `O` ssl field
+`org_unit` A String representing the `OU` ssl field
+`country` A String representing the `C` ssl field
+`expire` A Fixnum reprenting the number of days from _now_ to expire the cert
+`key_file` Optional A string to the key file to use. If no key is present it will generate and store one.
+`key_pass` A String that is the key's passphrase
+`key_length` A Fixnum reprenting your desired Bit Length _Default: 2048_
+`owner` The owner of the files _Default: "root"_
+`group` The group of the files _Default: "root"_
+`mode`  The mode to store the files in _Default: "0400"_
+
+#### Example usage
+
+```ruby
+openssl_x509 "/tmp/mycert.pem" do
+  common_name "www.f00bar.com"
+  org "Foo Bar"
+  org_unit "Lab"
+  country "US"
+end
+```
+
+
+License & Authors
+-----------------
+- Jesse Nelson (<spheromak@gmail.com>)
+- Joshua Timberman (<joshua@opscode.com>)
+- Seth Vargo (<sethvargo@gmail.com>)
+
 ```text
 Copyright:: 2009-2011, Opscode, Inc
-Copyright:: 2014, Chef Software, Inc <legal@getchef.com>
+Copyright:: 2014-2015, Chef Software, Inc <legal@getchef.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/libraries/random_password.rb
+++ b/libraries/random_password.rb
@@ -1,0 +1,82 @@
+#
+# Cookbook Name:: openssl
+# Library:: random_password
+# Author:: Seth Vargo <sethvargo@gmail.com>
+#
+# Copyright 2015, Seth Vargo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module OpenSSLCookbook
+  module RandomPassword
+    # Override the included method to require securerandom if it is not defined.
+    # This avoids the need to load the class on each Chef run unless the user is
+    # explicitly requiring it.
+    def self.included(base)
+      require 'securerandom' unless defined?(SecureRandom)
+    end
+
+    class InvalidPasswordMode < StandardError
+      def initialize(given, acceptable)
+        super <<-EOH
+The given password mode '#{given}' is not valid. Valid password modes are :hex,
+:base64, and :random_bytes!
+EOH
+      end
+    end
+
+    #
+    # Generates a random password using {SecureRandom}.
+    #
+    # @example Generating a random (hex) password (of 20 characters)
+    #   random_password #=> "1930e99aa035083bdd93d1d8f11cb7ac8f625c9c"
+    #
+    # @example Generating a random base64 password that is 50 characters
+    #   random_password(mode: :base64, length: 50) #=> "72o5oVbKHHEVYj1nOgFB2EijnzZfnrbfasVuF+oRH8wMgb0QWoYZF/OkrQricp1ENoI="
+    #
+    # @example Generate a password with a forced encoding
+    #   random_password(encoding: "ASCII")
+    #
+    # @param [Hash] options
+    # @option options [Fixnum] :length
+    #   the number of bits to use in the password
+    # @option options [Symbol] :mode
+    #   the type of random password to generate - valid values are
+    #   `:hex`, `:base64`, or `:random_bytes`
+    # @option options [String, Symbol, Constant] :encoding
+    #   the encoding to force (default is "UTF-8")
+    #
+    # @return [String]
+    #
+    def random_password(options = {})
+      length   = options[:length] || 20
+      mode     = options[:mode] || :hex
+      encoding = options[:encoding] || "UTF-8"
+
+      # Convert to a "proper" length, since the size is actually in bytes
+      length = case mode
+      when :hex
+        length / 2
+      when :base64
+        length * 3 / 4
+      when :random_bytes
+        length
+      else
+        raise InvalidPasswordMode.new(mode)
+      end
+
+      SecureRandom.send(mode, length).force_encoding(encoding)
+    end
+  end
+end

--- a/libraries/random_password.rb
+++ b/libraries/random_password.rb
@@ -28,7 +28,7 @@ module OpenSSLCookbook
     end
 
     class InvalidPasswordMode < StandardError
-      def initialize(given, acceptable)
+      def initialize(given)
         super <<-EOH
 The given password mode '#{given}' is not valid. Valid password modes are :hex,
 :base64, and :random_bytes!

--- a/spec/libraries/random_password_spec.rb
+++ b/spec/libraries/random_password_spec.rb
@@ -40,6 +40,12 @@ describe OpenSSLCookbook::RandomPassword do
         # depending on the encoding and whatnot...
         expect { instance.random_password(mode: :random_bytes) }.to_not raise_error
       end
+
+      it "raises an error if the mode is invalid" do
+        expect {
+          instance.random_password(mode: :bacon)
+        }.to raise_error(OpenSSLCookbook::RandomPassword::InvalidPasswordMode)
+      end
     end
 
     context "with the :encoding option" do

--- a/spec/libraries/random_password_spec.rb
+++ b/spec/libraries/random_password_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../spec_helper'
+require_relative '../../libraries/random_password'
+
+describe OpenSSLCookbook::RandomPassword do
+  let(:instance) do
+    Class.new { include OpenSSLCookbook::RandomPassword }.new
+  end
+
+  describe ".included" do
+    it "requires securerandom" do
+      instance
+      expect(defined?(SecureRandom)).to_not be(false)
+    end
+  end
+
+  describe "#random_password" do
+    context "with no options" do
+      it "returns a random hex password" do
+        expect(instance.random_password).to match(/[a-z0-9]{20}/)
+      end
+    end
+
+    context "with the :length option" do
+      it "returns a password with the given length" do
+        expect(instance.random_password(length: 50).size).to eq(50)
+      end
+    end
+
+    context "with the :mode option" do
+      it "returns a :hex password with :hex" do
+        expect(instance.random_password(mode: :hex)).to match(/[a-z0-9]{20}/)
+      end
+
+      it "returns a :base64 password with :base64" do
+        expect(instance.random_password(mode: :base64).size).to eq(20)
+      end
+
+      it "returns a :random_bytes password with :random_bytes" do
+        # There's nothing to really assert here, since the length can vary
+        # depending on the encoding and whatnot...
+        expect { instance.random_password(mode: :random_bytes) }.to_not raise_error
+      end
+    end
+
+    context "with the :encoding option" do
+      it "returns a password with the forced encoding" do
+        expect(instance.random_password(encoding: "ASCII").encoding.to_s).to eq("US-ASCII")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,5 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
-  config.color_enabled = true
   config.formatter = :documentation
 end


### PR DESCRIPTION
The current method for generating secure passwords is outdated and rather inefficient. This introduces a new module (under a proper namespace, with test coverage) that adds a set of new features (all documented inline and in the README) for generating passwords using `SecureRandom`.

- Fixes #12 
- Fixes #8 
- Closes #13

Commits are slit out in case you want to CP.

/cc @martinb3 for feedback
/cc @jtimberman for review