### PR TITLE
Add Serverspec Suite

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -94,15 +94,6 @@ platforms:
   - recipe[apt]
 
 suites:
-- name: upgrade
+- name: lwrp_x509
   run_list:
-  - recipe[test]
-  - recipe[postfix]
-  - recipe[openssl::upgrade]
-  attributes:
-    openssl:
-      restart_services:
-      - postfix
-- name: lwrp
-  run_list:
-  - recipe[test::lwrp]
+  - recipe[test::lwrp_x509]

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,7 @@ source 'https://supermarket.chef.io'
 
 group :integration do
   cookbook 'test', :path => 'test/fixtures/cookbooks/test'
+  cookbook 'apt'
 end
 
 metadata

--- a/spec/unit/recipes/lwrp_x509_spec.rb
+++ b/spec/unit/recipes/lwrp_x509_spec.rb
@@ -32,6 +32,14 @@ describe 'test::lwrp_x509' do
       runner.converge(described_recipe)
     end
 
+    it 'adds a file resource \'/etc/ssl_test/mycert.crt\' with action delete' do
+      expect(chef_run).to delete_file('/etc/ssl_test/mycert.crt')
+    end
+
+    it 'adds a file resource \'/etc/ssl_test/mycert.key\' with action delete' do
+      expect(chef_run).to delete_file('/etc/ssl_test/mycert.key')
+    end
+
     it 'adds a directory resource \'/etc/ssl_test\' with action create' do
       expect(chef_run).to create_directory('/etc/ssl_test')
     end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: test
 # Recipe:: default
 #
-# Copyright:: Copyright (c) 2014, Chef Software, Inc. <legal@chef.io>
+# Copyright:: Copyright (c) 2014-2015, Chef Software, Inc. <legal@chef.io>
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/fixtures/cookbooks/test/recipes/httpd.rb
+++ b/test/fixtures/cookbooks/test/recipes/httpd.rb
@@ -1,1 +1,21 @@
+#
+# Cookbook Name:: test
+# Recipe:: httpd
+#
+# Copyright:: Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 service('httpd') { action :nothing }

--- a/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
+++ b/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
@@ -1,7 +1,38 @@
+#
+# Cookbook Name:: test
+# Recipe:: lwrp_x509
+#
+# Copyright:: Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Ensure files are not present, so the lwrp makes new keys every time
+file '/etc/ssl_test/mycert.crt' do
+  action :delete
+end
+
+file '/etc/ssl_test/mycert.key' do
+  action :delete
+end
+
+# Create directory if not already present
 directory '/etc/ssl_test' do
   recursive true
 end
 
+# Generate new key and certificate
 openssl_x509 '/etc/ssl_test/mycert.crt' do
   common_name 'mycert.example.com'
   org 'Test Kitchen Example'

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec

--- a/test/integration/lwrp_x509/serverspec/lwrp_x509_spec.rb
+++ b/test/integration/lwrp_x509/serverspec/lwrp_x509_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'openssl'
+
+describe 'test::lwrp_x509' do
+  # Serverspec examples can be found at
+  # http://serverspec.org/resource_types.html
+  describe command('openssl rsa -in /etc/ssl_test/mycert.key -check -noout') do
+    it 'generates a valid private key' do
+      expect(subject.exit_status).to eq 0
+    end
+  end
+
+  describe command('openssl x509 -in /etc/ssl_test/mycert.crt -noout') do
+    it 'generates a valid x509 cert' do
+      expect(subject.exit_status).to eq 0
+    end
+  end
+
+  it 'The certificate is verifiable against the key file' do
+    cert = OpenSSL::X509::Certificate.new File.read('/etc/ssl_test/mycert.crt')
+    key = OpenSSL::PKey::RSA.new File.read('/etc/ssl_test/mycert.key')
+    expect(cert.verify(key)).to be_truthy
+  end
+end


### PR DESCRIPTION
- Add missing final newline to berskfile
- Remove update suite from kitchen.yml, as this is now tested in Chefspec
- Update test/recipes/lwrp_x509.rb to delete existing certificate files before creating new ones
- Add explicit license to test recipes
- Create serverspec suite to verify x509 lwrp
- Resolves #16 