### PR TITLE
Verify existing RSA key in x509 lwrp

### DIFF
--- a/providers/x509.rb
+++ b/providers/x509.rb
@@ -55,7 +55,7 @@ protected
 
   def key
     @key ||= if key_file_valid?(key_file, new_resource.key_pass)
-               OpenSSL::PKey::RSA.new File.read(key_file), new_resource.key_pass
+               OpenSSL::PKey::RSA.new ::File.read(key_file), new_resource.key_pass
              else
                OpenSSL::PKey::RSA.new(new_resource.key_length)
              end

--- a/providers/x509.rb
+++ b/providers/x509.rb
@@ -54,7 +54,7 @@ protected
   end
 
   def key
-    @key ||= if ::File.exist? key_file
+    @key ||= if key_file_valid?(key_file, new_resource.key_pass)
                OpenSSL::PKey::RSA.new File.read(key_file), new_resource.key_pass
              else
                OpenSSL::PKey::RSA.new(new_resource.key_length)

--- a/spec/unit/recipes/lwrp_x509_spec.rb
+++ b/spec/unit/recipes/lwrp_x509_spec.rb
@@ -40,6 +40,10 @@ describe 'test::lwrp_x509' do
       expect(chef_run).to delete_file('/etc/ssl_test/mycert.key')
     end
 
+    it 'adds a file resource \'/etc/ssl_test/mycert2.crt\' with action delete' do
+      expect(chef_run).to delete_file('/etc/ssl_test/mycert2.crt')
+    end
+
     it 'adds a directory resource \'/etc/ssl_test\' with action create' do
       expect(chef_run).to create_directory('/etc/ssl_test')
     end

--- a/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
+++ b/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
@@ -27,6 +27,10 @@ file '/etc/ssl_test/mycert.key' do
   action :delete
 end
 
+file '/etc/ssl_test/mycert2.crt' do
+  action :delete
+end
+
 # Create directory if not already present
 directory '/etc/ssl_test' do
   recursive true
@@ -38,4 +42,13 @@ openssl_x509 '/etc/ssl_test/mycert.crt' do
   org 'Test Kitchen Example'
   org_unit 'Kitchens'
   country 'UK'
+end
+
+# Generate a new key from an existing certificate
+openssl_x509 '/etc/ssl_test/mycert2.crt' do
+  common_name 'mycert2.example.com'
+  org 'Test Kitchen Example'
+  org_unit 'Kitchens'
+  country 'UK'
+  key_file '/etc/ssl_test/mycert.key'
 end


### PR DESCRIPTION
If the x509 LWRP is called with an existing RSA key, it will now validate that key instead of just testing that the file exists on the disk.

- Resolves #15 