### PR TITLE
Refactor input validation for LWRPs

### DIFF
--- a/resources/dhparam.rb
+++ b/resources/dhparam.rb
@@ -3,8 +3,8 @@ actions [:create]
 default_action :create
 
 attribute :name,        :kind_of => String,  :name_attribute => true
-attribute :key_length,  :kind_of => Integer, :default => 2048
+attribute :key_length,  :equal_to => [1024, 2048, 4096, 8192], :default => 2048
 attribute :generator,   :equal_to => [2, 5], :default => 2
 attribute :owner,       :kind_of => String
 attribute :group,       :kind_of => String
-attribute :mode,        :kind_of => [Fixnum, String]
+attribute :mode,        :kind_of => [Integer, String]

--- a/resources/x509.rb
+++ b/resources/x509.rb
@@ -5,12 +5,12 @@ default_action :create
 attribute :name,        :kind_of => String,  :name_attribute => true
 attribute :owner,       :kind_of => String
 attribute :group,       :kind_of => String
-attribute :expire,      :kind_of => Fixnum
-attribute :mode
+attribute :expire,      :kind_of => Integer
+attribute :mode,        :kind_of => [Integer, String]
 attribute :org,         :kind_of => String, :required => true
 attribute :org_unit,    :kind_of => String, :required => true
 attribute :country,     :kind_of => String, :required => true
 attribute :common_name, :kind_of => String, :required => true
 attribute :key_file,    :kind_of => String, :default => nil
 attribute :key_pass,    :kind_of => String, :default => nil
-attribute :key_length,  :kind_of => Fixnum, :default => 2048
+attribute :key_length,  :equal_to => [1024, 2048, 4096, 8192], :default => 2048


### PR DESCRIPTION
- Only accept powers of 2 > 1024 and <= 8192 for key_length in x509 & dhparam LWRPs
- Standardize on Integer as validation type (was mixed Integer & Fixnum)
- Validate input of mode on x509 LWRP