### PR TITLE
Test cleanup

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,8 +1,6 @@
 module OpenSSLCookbook
   # Helper functions for the OpenSSL cookbook.
   module Helpers
-    include Chef::DSL::IncludeRecipe
-
     def self.included(_base)
       require 'openssl' unless defined?(OpenSSL)
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -15,6 +15,12 @@ module OpenSSLCookbook
       key.private?
     end
 
+    def get_key_filename(cert_filename)
+      cert_file_path, cert_filename = ::File.split(cert_filename)
+      cert_filename = ::File.basename(cert_filename, ::File.extname(cert_filename))
+      cert_file_path + ::File::SEPARATOR + cert_filename + '.key'
+    end
+
     def dhparam_pem_valid?(dhparam_pem_path)
       # Check if the dhparam.pem file exists
       # Verify the dhparam.pem file contains a key

--- a/spec/unit/helpers/helpers_spec.rb
+++ b/spec/unit/helpers/helpers_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 require_relative '../../../libraries/helpers'
 
 describe OpenSSLCookbook::Helpers do
@@ -15,6 +14,7 @@ describe OpenSSLCookbook::Helpers do
 
   describe '#key_file_valid?' do
     require 'tempfile'
+    require 'openssl' unless defined?(OpenSSL)
 
     cipher =  OpenSSL::Cipher::Cipher.new('des3')
 

--- a/spec/unit/helpers/helpers_spec.rb
+++ b/spec/unit/helpers/helpers_spec.rb
@@ -120,4 +120,20 @@ describe OpenSSLCookbook::Helpers do
       end
     end
   end
+
+  describe '#get_key_filename' do
+    context 'When the input is not a string' do
+      it 'Throws a TypeError' do
+        expect do
+          instance.get_key_filename(33)
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'when the input is a string' do
+      it 'Generates valid keyfile names' do
+        expect(instance.get_key_filename('/etc/temp.crt')).to match('/etc/temp.key')
+      end
+    end
+  end
 end

--- a/spec/unit/recipes/lwrp_dhparam_spec.rb
+++ b/spec/unit/recipes/lwrp_dhparam_spec.rb
@@ -33,7 +33,8 @@ describe 'test::lwrp_dhparam' do
     end
 
     it 'adds a file resource \'/etc/ssl_test/dhparam.pem\' with action delete' do
-      expect(chef_run).to delete_file('/etc/ssl_test/dhparam.pem')
+      expect(chef_run).to delete_file('any potential existing key')
+        .with(path: '/etc/ssl_test/dhparam.pem')
     end
 
     it 'adds a directory resource \'/etc/ssl_test\' with action create' do

--- a/spec/unit/recipes/lwrp_x509_spec.rb
+++ b/spec/unit/recipes/lwrp_x509_spec.rb
@@ -33,15 +33,15 @@ describe 'test::lwrp_x509' do
     end
 
     it 'adds a file resource \'/etc/ssl_test/mycert.crt\' with action delete' do
-      expect(chef_run).to delete_file('/etc/ssl_test/mycert.crt')
+      expect(chef_run).to delete_file('Any potential existing cert')
     end
 
     it 'adds a file resource \'/etc/ssl_test/mycert.key\' with action delete' do
-      expect(chef_run).to delete_file('/etc/ssl_test/mycert.key')
+      expect(chef_run).to delete_file('Any potential existing key')
     end
 
     it 'adds a file resource \'/etc/ssl_test/mycert2.crt\' with action delete' do
-      expect(chef_run).to delete_file('/etc/ssl_test/mycert2.crt')
+      expect(chef_run).to delete_file('Any potential existing second cert')
     end
 
     it 'adds a directory resource \'/etc/ssl_test\' with action create' do

--- a/test/fixtures/cookbooks/test/recipes/lwrp_dhparam.rb
+++ b/test/fixtures/cookbooks/test/recipes/lwrp_dhparam.rb
@@ -19,7 +19,8 @@
 #
 
 # Ensure files are not present, so the lwrp makes new keys every time
-file '/etc/ssl_test/dhparam.pem' do
+file 'any potential existing key' do
+  path '/etc/ssl_test/dhparam.pem'
   action :delete
 end
 

--- a/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
+++ b/test/fixtures/cookbooks/test/recipes/lwrp_x509.rb
@@ -19,15 +19,18 @@
 #
 
 # Ensure files are not present, so the lwrp makes new keys every time
-file '/etc/ssl_test/mycert.crt' do
+file 'Any potential existing cert' do
+  path '/etc/ssl_test/mycert.crt'
   action :delete
 end
 
-file '/etc/ssl_test/mycert.key' do
+file 'Any potential existing key' do
+  path '/etc/ssl_test/mycert.key'
   action :delete
 end
 
-file '/etc/ssl_test/mycert2.crt' do
+file 'Any potential existing second cert' do
+  path '/etc/ssl_test/mycert2.crt'
   action :delete
 end
 
@@ -44,7 +47,7 @@ openssl_x509 '/etc/ssl_test/mycert.crt' do
   country 'UK'
 end
 
-# Generate a new key from an existing certificate
+# Generate a new certificate from an existing key
 openssl_x509 '/etc/ssl_test/mycert2.crt' do
   common_name 'mycert2.example.com'
   org 'Test Kitchen Example'


### PR DESCRIPTION
Cleanup tests:
- Make library tests faster by not requiring Chef & Chefspec where not needed
- Clean up a lot of the resource clone WARNs in the x509 lwrp test
- Clean up all of the resource clone WARNs in the dhparam lwrp test